### PR TITLE
Fix error with part name

### DIFF
--- a/backend/teldrive/teldrive.go
+++ b/backend/teldrive/teldrive.go
@@ -620,7 +620,7 @@ func (f *Fs) putUnchecked(ctx context.Context, in0 io.Reader, src fs.ObjectInfo,
 		encryptFile = uploadFile.Parts[0].Encrypted
 	}
 
-	var partName string
+	partName := leaf
 
 	for partNo := 1; partNo <= int(totalParts); partNo++ {
 


### PR DESCRIPTION
Hi. This PR fixes an error with `partName` being sent empty when `randomise_part` is false, and total parts of a file are equal to 1.

**Changes:**

- Initialize `partName` var with the file name.

Please review and let me know if any further changes or adjustments are needed. Thank you.